### PR TITLE
chore(ci): add Python 3.14 support

### DIFF
--- a/.github/workflows/tests-unit.yaml
+++ b/.github/workflows/tests-unit.yaml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ['3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
 
     runs-on: ${{ matrix.os }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "mozilla-ai-tinyagent"
 readme = "README.md"
 license = {text = "Apache-2.0"}
-requires-python = ">=3.11,<3.14"
+requires-python = ">=3.11,<3.15"
 dynamic = ["version"]
 description = "A minimal agent framework with first-class tracing, callbacks, MCP, and serving support."
 dependencies = [


### PR DESCRIPTION
## Description
Add official Python 3.14 support by raising the `requires-python` upper bound and testing against 3.14 in the unit test CI matrix.

Changes:
- `pyproject.toml`: `requires-python` from `>=3.11,<3.14` to `>=3.11,<3.15`
- `.github/workflows/tests-unit.yaml`: add `3.14` to the `python-version` matrix

No source code changes were required; existing tests pass on Python 3.14.

## PR Type

- Infrastructure

## Relevant issues

N/A

## Checklist
- [x] I understand the code I am submitting.
- [ ] I have added unit tests that prove my fix/feature works.
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally.
- [ ] Documentation was updated where necessary.
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/tinyagent/blob/main/CONTRIBUTING.md).
- [ ] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Composer 2.5 (Cursor)
- AI Developer Tool used: Cursor
- Any other info you'd like to share: Used to identify required changes for Python 3.14 compatibility and draft the PR description.

When answering questions by the reviewer, please respond yourself; do not paste reviewer comments into an AI system and paste back its answer. We want to discuss with you, not your AI.

- [ ] I am an AI Agent filling out this form (check box if true).

Resolves #16